### PR TITLE
fix: remove highlight from step 2 activity cards

### DIFF
--- a/src/pages/my-exercises/FavoriteActivitiesSection.tsx
+++ b/src/pages/my-exercises/FavoriteActivitiesSection.tsx
@@ -276,14 +276,14 @@ export const FavoriteActivitiesSection: React.FC = () => {
                       return (
                         <div key={favoriteActivity.id} className="space-y-3">
                           {/* Full-size Activity Card */}
-                          <div className="rounded-lg overflow-hidden bg-primary/10 shadow-md">
+                          <div className="rounded-lg overflow-hidden">
                             <ActivityCard
                               activity={finalActivity}
-                              isSelected={true}
+                              isSelected={false}
                               onClick={() => {}} // No click action needed in step 2
                             />
                           </div>
-                          
+
                           {/* Body Area Dropdown */}
                           <Select
                             value={bodyAreaSelections[favoriteActivity.activity] || favoriteActivity.pain_area || ""}


### PR DESCRIPTION
## Summary
- show selected activities in step 2 without highlight styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any type, require import issues, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6894667dba148326974591fa54bce346